### PR TITLE
Fixed Bug In HDRIHAVEN Scraper

### DIFF
--- a/blender/LilySurfaceScraper/Scrapers/HdriHavenScraper.py
+++ b/blender/LilySurfaceScraper/Scrapers/HdriHavenScraper.py
@@ -81,7 +81,7 @@ class HdriHavenScraper(AbstractScraper):
         var_name = variants[variant_index]
         material_data.name = "hdrihaven/" + base_name + '/' + var_name
 
-        url = "https://hdrihaven.com" + variant_data[variant_index].attrib['href']
+        url = variant_data[variant_index].attrib['href']
         if url.endswith('.exr') or url.endswith('.hdr') or url.endswith('.jpg'):
             map_url = url
         else:


### PR DESCRIPTION
The addon wasn't working for me and I think this fixed it. I think this is because it appended 
`url = "https://hdrihaven.com" + variant_data[variant_index].attrib['href']`
which caused the url to be https://hdrihaven.comhttps://download.polyhaven.com/HDRIs/1k/oberer_kuhberg_1k.exr which resulted in a error.