### PR TITLE
Add option to create blackbody node on ies import

### DIFF
--- a/blender/LilySurfaceScraper/CyclesLightData.py
+++ b/blender/LilySurfaceScraper/CyclesLightData.py
@@ -32,8 +32,9 @@ class CyclesLightData(LightData):
         energy = self.maps['energy']
 
         out = nodes.new(type="ShaderNodeOutputLight")
-        emmision = nodes.new(type="ShaderNodeEmission")
-        links.new(out.inputs['Surface'], emmision.outputs['Emission'])
+        emission = nodes.new(type="ShaderNodeEmission")
+        
+        links.new(out.inputs['Surface'], emission.outputs['Emission'])
 
         iesNode = nodes.new(type="ShaderNodeTexIES")
         if pref.ies_pack_files:
@@ -42,7 +43,7 @@ class CyclesLightData(LightData):
         else:
             iesNode.mode = "EXTERNAL"
             iesNode.filepath = ies
-        links.new(iesNode.outputs['Fac'], emmision.inputs["Strength"])
+        links.new(iesNode.outputs['Fac'], emission.inputs["Strength"])
 
         if pref.ies_use_strength:
             if pref.ies_light_strength:
@@ -51,6 +52,11 @@ class CyclesLightData(LightData):
                 links.new(value.outputs["Value"], iesNode.inputs["Strength"])
             else:
                 light.energy = energy
+        
+        if pref.ies_add_blackbody:
+            blacbody = nodes.new(type="ShaderNodeBlackbody")
+            blacbody.inputs["Temperature"].default_value = 7000
+            links.new(blacbody.outputs["Color"], emission.inputs["Color"])
 
         autoAlignNodes(out)
 

--- a/blender/LilySurfaceScraper/preferences.py
+++ b/blender/LilySurfaceScraper/preferences.py
@@ -59,6 +59,11 @@ class LilySurfaceScraperPreferences(bpy.types.AddonPreferences):
         default=True,
     )
 
+    ies_add_blackbody: bpy.props.BoolProperty(
+        name="Add Blackbody node",
+        default=True,
+    )
+
     ies_light_strength: bpy.props.BoolProperty(
         name="Use in strength node",
         default=False,
@@ -87,6 +92,9 @@ class LilySurfaceScraperPreferences(bpy.types.AddonPreferences):
         layout.prop(self, "use_ground_hdri")
 
         layout.separator()
+        layout.label(text="Add a Backbody node as color input when importing IES textures")
+        layout.prop(self, "ies_add_blackbody")
+
         layout.label(text="Use the energy value from the IES library to determine the strength of the lamp")
         layout.prop(self, "ies_use_strength")
         if bool(self.ies_use_strength):


### PR DESCRIPTION
I added a option in the user preferences to add a blackbody node to the color input of the emission node for IES texture imports