### PR TITLE
Fix Issue #188: Add new normal map name

### DIFF
--- a/blender/LilySurfaceScraper/Scrapers/AmbientCgScraper.py
+++ b/blender/LilySurfaceScraper/Scrapers/AmbientCgScraper.py
@@ -106,6 +106,8 @@ class AmbientCgScraper(AbstractScraper):
             # New names
             'Color': 'baseColor',
             'Normal': 'normalInvertedY',
+            # newer normal name
+            'NormalDX': 'normalInvertedY',
             'Opacity': 'opacity',
             'Roughness': 'roughness',
             'Metalness': 'metallic',


### PR DESCRIPTION
AmbientCG switched from DirectX (DX) only to DirectX and OpenGL (GL) Normal maps
To fix this and keep the original behavior i just added the new name to the translation.
