### PR TITLE
The API on ieslibrary has changed

### DIFF
--- a/blender/LilySurfaceScraper/preferences.py
+++ b/blender/LilySurfaceScraper/preferences.py
@@ -44,6 +44,12 @@ class LilySurfaceScraperPreferences(bpy.types.AddonPreferences):
         default="LilySurface",
     )
 
+    ieslibrary_apikey: bpy.props.StringProperty(
+        name="ieslibrary API-Key",
+        subtype='NONE',
+        default="",
+    )
+
     use_ao: bpy.props.BoolProperty(
         name="Use AO map",
         default=False,
@@ -86,6 +92,10 @@ class LilySurfaceScraperPreferences(bpy.types.AddonPreferences):
         layout.label(text="It can either be relative to the blend file, or global to all files.")
         layout.label(text="If it is relative, you must always save the blend file before importing materials and worlds.")
         layout.prop(self, "texture_dir")
+
+        layout.label(text="For the import of lights from ieslibrary a valid API-Key is needed.")
+        layout.label(text="Get the API-Key from ieslibrary.com (login needed)")
+        layout.prop(self, "ieslibrary_apikey")
 
         split1 = layout.split(factor=1/3)
 


### PR DESCRIPTION
The API on ieslibrary was changed, without these changes, the import of lights will fail
This change includes a change in the preferences as well.

For testing you can create a new account on ieslibrary or use this API-Key (will expire in 7days)
47813e9e7c75980f2830578b49afa38f98c1259bcbccc35dfd357e329a2484fa
