### PR TITLE
Update CyclesMaterialData.py (fix for issues/236)

### DIFF
--- a/blender/LilySurfaceScraper/CyclesMaterialData.py
+++ b/blender/LilySurfaceScraper/CyclesMaterialData.py
@@ -247,7 +247,7 @@ class CyclesMaterialData(MaterialData):
                 base_color_output = basecolor_links[0].from_socket
                 mix_node = nodes.new(type="ShaderNodeMixRGB")
                 mix_node.blend_type = 'MULTIPLY'
-                mix_node.default_value = 1.
+                mix_node.inputs[0].default_value = 1
                 links.new(base_color_output, mix_node.inputs[1])
                 links.new(aoOutput, mix_node.inputs[2])
                 links.new(mix_node.outputs["Color"], self.principled_node.inputs["Base Color"])


### PR DESCRIPTION
when `Use AO Map` setting is on, setting the `Factor` value of the `Mix Node` to `1` was throwing error because it was addressed as `mix_node.default_value` and not `mix_node.inputs[0].default_value`
(was flagged as issue: https://github.com/eliemichel/LilySurfaceScraper/issues/236 )